### PR TITLE
chore: Use "actions/labeler@v5"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+chore:
+  - all:
+      - head-branch: ["topic/chore-"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
設定にブランチ名を使いたかったので "v5" を指定している(betaでもメジャーバージョンで指定できる？)。