### PR TITLE
chore: Use regexp instead of glob

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
 chore:
   - all:
-      - head-branch: ["**/chore-"]
+      - head-branch: ["^.+/chore-"]


### PR DESCRIPTION
```
Error: SyntaxError: Invalid regular expression: /**/chore-/: Nothing to repeat
Error: Invalid regular expression: /**/chore-/: Nothing to repeat
```